### PR TITLE
Add webhook delivery channel for order notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,49 @@ For example "I want to receive orders that contain backend in the name and do no
 
 At the moment, the following exchanges are available on the website: [freelance.ru](https://freelance.ru), [fl.ru](https://www.fl.ru), [weblancer.net](https://www.weblancer.net), [freelancehunt](https://freelancehunt.com/), [youdo](https://youdo.com/), [kwork](https://kwork.ru/), [freelancer](https://www.freelancer.com/), [truelancer](https://www.truelancer.com/).
 
+### Webhook notifications
+
+Besides email and Telegram, orders can be delivered to your own HTTP endpoint —
+a channel for integrations: it carries the orders themselves as JSON, not a
+rendered message.
+
+Set the address on the notifications page or via
+`PATCH /api/user/webhook?url=https://example.com/hooks/alert-job`
+(an empty value turns the channel off).
+
+The channel is independent: it does not replace email or Telegram, runs next to
+them and ignores quiet hours (`UserAlertTime`) — those are for humans, not for
+integrations. The global alerts toggle does switch it off.
+
+A `POST` is sent to the given address with `X-AlertJob-Event` and
+`X-AlertJob-User` headers and this body:
+
+```json
+{
+  "url": "https://example.com/hooks/alert-job",
+  "userUuid": "0d2c...",
+  "type": "ORDER",
+  "sentAt": "2025-09-01T10:15:30Z",
+  "orders": [
+    {
+      "title": "Python parser needed",
+      "link": "https://freelance.ru/projects/1",
+      "dateTime": "2025-09-01T10:15:00Z",
+      "price": { "value": 15000, "currency": "RUB" },
+      "sourceSite": { "categoryName": "Development", "subCategoryName": "Python" },
+      "moduleName": "Backend"
+    }
+  ]
+}
+```
+
+Only external `http`/`https` addresses are accepted: anything inside the
+perimeter (loopback, private and link-local ranges) is rejected with 400 —
+otherwise a user could make the service walk the internal network.
+
+After `webhook.max.failures` (10 by default) consecutive failures the channel
+goes silent; saving a new address resets the counter.
+
 The project has a microservice architecture.<br>
 Used technologies:
 <ol>

--- a/README_RU.md
+++ b/README_RU.md
@@ -8,6 +8,47 @@
 
 На данный момент на сайте доступны следующие биржи: [freelance.ru](https://freelance.ru), [fl.ru](https://www.fl.ru), [weblancer.net](https://www.weblancer.net), [freelancehunt](https://freelancehunt.com/), [youdo](https://youdo.com/), [kwork](https://kwork.ru/), [freelancer](https://www.freelancer.com/), [truelancer](https://www.truelancer.com/).
 
+### Уведомления на webhook
+
+Кроме почты и телеграма заказы можно получать на свой HTTP-эндпоинт — это канал
+для интеграций: приходит не отрендеренный текст, а сами заказы в JSON.
+
+Адрес задаётся на странице настройки уведомлений или запросом
+`PATCH /api/user/webhook?url=https://example.com/hooks/alert-job`
+(пустое значение выключает канал).
+
+Канал независимый: он не заменяет почту и телеграм, работает рядом с ними и не
+подчиняется расписанию тишины (`UserAlertTime`) — оно про людей, а не про
+интеграции. Общий тумблер уведомлений webhook выключает.
+
+`POST` на указанный адрес, заголовки `X-AlertJob-Event` и `X-AlertJob-User`, тело:
+
+```json
+{
+  "url": "https://example.com/hooks/alert-job",
+  "userUuid": "0d2c...",
+  "type": "ORDER",
+  "sentAt": "2025-09-01T10:15:30Z",
+  "orders": [
+    {
+      "title": "Нужен парсер на Python",
+      "link": "https://freelance.ru/projects/1",
+      "dateTime": "2025-09-01T10:15:00Z",
+      "price": { "value": 15000, "currency": "RUB" },
+      "sourceSite": { "categoryName": "Разработка", "subCategoryName": "Python" },
+      "moduleName": "Backend"
+    }
+  ]
+}
+```
+
+Принимаются только внешние `http`/`https` адреса: адреса внутри периметра
+(loopback, приватные и link-local диапазоны) отклоняются с кодом 400, иначе
+пользователь мог бы заставить сервис ходить по внутренней сети.
+
+После `webhook.max.failures` (по умолчанию 10) неудачных доставок подряд канал
+замолкает; сохранение нового адреса сбрасывает счётчик.
+
 Проект писался на микросервисной архитектуре.<br>
 Используемые технологии:
 

--- a/common-alert-job/pom.xml
+++ b/common-alert-job/pom.xml
@@ -29,6 +29,12 @@
             <artifactId>spring-boot-starter</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 	
 </project>

--- a/common-alert-job/src/main/java/by/gdev/common/model/WebhookNotification.java
+++ b/common-alert-job/src/main/java/by/gdev/common/model/WebhookNotification.java
@@ -1,0 +1,33 @@
+package by.gdev.common.model;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Полезная нагрузка доставки уведомления на пользовательский webhook.
+ * В отличие от почты и телеграма отправляются не отрендеренные строки,
+ * а сами заказы — получатель разбирает их машинно.
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class WebhookNotification {
+
+	/** Адрес, на который нужно доставить уведомление. */
+	private String url;
+
+	/** UUID пользователя-получателя (Keycloak subject). */
+	private String userUuid;
+
+	/** Тип события. */
+	private NotificationType type = NotificationType.ORDER;
+
+	/** Время формирования доставки, ISO-8601 UTC. */
+	private String sentAt;
+
+	/** Заказы, попавшие под фильтры пользователя. */
+	private List<OrderDTO> orders;
+}

--- a/common-alert-job/src/main/java/by/gdev/common/util/WebhookUrlValidator.java
+++ b/common-alert-job/src/main/java/by/gdev/common/util/WebhookUrlValidator.java
@@ -1,0 +1,71 @@
+package by.gdev.common.util;
+
+import java.net.InetAddress;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.UnknownHostException;
+import java.util.Locale;
+
+/**
+ * Проверка пользовательского адреса webhook.
+ *
+ * Адрес приходит от пользователя, а запрос по нему делает notification-модуль,
+ * который стоит внутри docker-сети рядом с core, keycloak и базой. Без проверки
+ * это SSRF: пользователь указал бы http://core:8017/... и заставил бы сервис
+ * ходить по внутренним адресам от своего имени. Поэтому режем всё, что не
+ * http/https, и все адреса, ведущие внутрь периметра.
+ */
+public final class WebhookUrlValidator {
+
+	private WebhookUrlValidator() {
+	}
+
+	public static void validate(String url) {
+		if (url == null || url.isBlank()) {
+			throw new IllegalArgumentException("webhook url is empty");
+		}
+		if (url.length() > 512) {
+			throw new IllegalArgumentException("webhook url is too long");
+		}
+
+		URI uri;
+		try {
+			uri = new URI(url.trim());
+		} catch (URISyntaxException e) {
+			throw new IllegalArgumentException("webhook url is malformed");
+		}
+
+		String scheme = uri.getScheme() == null ? "" : uri.getScheme().toLowerCase(Locale.ROOT);
+		if (!scheme.equals("http") && !scheme.equals("https")) {
+			throw new IllegalArgumentException("only http and https are allowed");
+		}
+
+		String host = uri.getHost();
+		if (host == null || host.isBlank()) {
+			throw new IllegalArgumentException("webhook url has no host");
+		}
+
+		InetAddress[] addresses;
+		try {
+			addresses = InetAddress.getAllByName(host);
+		} catch (UnknownHostException e) {
+			throw new IllegalArgumentException("webhook host is not resolvable");
+		}
+
+		for (InetAddress address : addresses) {
+			if (address.isLoopbackAddress() || address.isAnyLocalAddress() || address.isLinkLocalAddress()
+					|| address.isSiteLocalAddress() || address.isMulticastAddress()) {
+				throw new IllegalArgumentException("webhook host points to an internal address");
+			}
+		}
+	}
+
+	public static boolean isValid(String url) {
+		try {
+			validate(url);
+			return true;
+		} catch (IllegalArgumentException e) {
+			return false;
+		}
+	}
+}

--- a/common-alert-job/src/test/java/by/gdev/common/util/WebhookUrlValidatorTest.java
+++ b/common-alert-job/src/test/java/by/gdev/common/util/WebhookUrlValidatorTest.java
@@ -1,0 +1,36 @@
+package by.gdev.common.util;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class WebhookUrlValidatorTest {
+
+	@Test
+	void publicHttpsUrlIsAllowed() {
+		assertTrue(WebhookUrlValidator.isValid("https://example.com/hooks/alert-job"));
+	}
+
+	@Test
+	void nonHttpSchemesAreRejected() {
+		assertFalse(WebhookUrlValidator.isValid("ftp://example.com/hook"));
+		assertFalse(WebhookUrlValidator.isValid("file:///etc/passwd"));
+	}
+
+	@Test
+	void internalAddressesAreRejected() {
+		assertFalse(WebhookUrlValidator.isValid("http://127.0.0.1:8017/api/orders"));
+		assertFalse(WebhookUrlValidator.isValid("http://localhost/hook"));
+		assertFalse(WebhookUrlValidator.isValid("http://10.0.0.5/hook"));
+		assertFalse(WebhookUrlValidator.isValid("http://192.168.1.10/hook"));
+		assertFalse(WebhookUrlValidator.isValid("http://169.254.169.254/latest/meta-data"));
+	}
+
+	@Test
+	void emptyUrlIsRejected() {
+		assertThrows(IllegalArgumentException.class, () -> WebhookUrlValidator.validate(""));
+		assertThrows(IllegalArgumentException.class, () -> WebhookUrlValidator.validate(null));
+	}
+}

--- a/core-alert-job/src/main/java/by/gdev/alert/job/core/controller/MainController.java
+++ b/core-alert-job/src/main/java/by/gdev/alert/job/core/controller/MainController.java
@@ -68,6 +68,12 @@ public class MainController {
 	return ResponseEntity.ok(coreService.changeUserTelegram(uuid, telegramId));
     }
 
+    @PatchMapping("user/webhook")
+    public ResponseEntity<Mono<Void>> changeUserWebhook(@RequestHeader(HeaderName.UUID_USER_HEADER) String uuid,
+	    @RequestParam(name = "url", required = false) String url) {
+	return ResponseEntity.ok(coreService.changeUserWebhook(uuid, url));
+    }
+
     @PatchMapping("user/alert-time")
     public ResponseEntity<Mono<UserAlertTimeDTO>> createAlertTime(
 	    @RequestHeader(HeaderName.UUID_USER_HEADER) String uuid, @RequestBody AlertTime alertTime) {

--- a/core-alert-job/src/main/java/by/gdev/alert/job/core/exeption/InvalidWebhookUrlException.java
+++ b/core-alert-job/src/main/java/by/gdev/alert/job/core/exeption/InvalidWebhookUrlException.java
@@ -1,0 +1,7 @@
+package by.gdev.alert.job.core.exeption;
+
+public class InvalidWebhookUrlException extends RuntimeException {
+    public InvalidWebhookUrlException(String message) {
+        super(message);
+    }
+}

--- a/core-alert-job/src/main/java/by/gdev/alert/job/core/handler/GlobalExceptionHandler.java
+++ b/core-alert-job/src/main/java/by/gdev/alert/job/core/handler/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package by.gdev.alert.job.core.handler;
 
+import by.gdev.alert.job.core.exeption.InvalidWebhookUrlException;
 import by.gdev.alert.job.core.exeption.ai.*;
 import by.gdev.alert.job.core.exeption.ai.binding.BindingAlreadyExistsException;
 import by.gdev.alert.job.core.exeption.ai.binding.BindingNotFoundException;
@@ -35,6 +36,11 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(OrderModuleNotFoundException.class)
     public ResponseEntity<?> handleOrderModuleNotFound(OrderModuleNotFoundException ex) {
         return ResponseEntity.status(404).body(ex.getMessage());
+    }
+
+    @ExceptionHandler(InvalidWebhookUrlException.class)
+    public ResponseEntity<?> handleInvalidWebhookUrl(InvalidWebhookUrlException e) {
+        return ResponseEntity.badRequest().body(Map.of("error", e.getMessage()));
     }
 
     @ExceptionHandler(InvalidSiteIdException.class)

--- a/core-alert-job/src/main/java/by/gdev/alert/job/core/model/AppUserDTO.java
+++ b/core-alert-job/src/main/java/by/gdev/alert/job/core/model/AppUserDTO.java
@@ -11,5 +11,6 @@ public class AppUserDTO {
     private Long telegram;
     private boolean switchOffAlerts;
     private boolean defaultSendType;
+    private String webhookUrl;
     private List<UserAlertTimeDTO> alertTimeDTO;
 }

--- a/core-alert-job/src/main/java/by/gdev/alert/job/core/model/db/AppUser.java
+++ b/core-alert-job/src/main/java/by/gdev/alert/job/core/model/db/AppUser.java
@@ -28,4 +28,6 @@ public class AppUser extends BasicId {
     @OneToMany(mappedBy = "user")
     private Set<DelayOrderNotification> delayOrderNotifications;
     private Integer telegramFailCount = 0;
+    private String webhookUrl;
+    private Integer webhookFailCount = 0;
 }

--- a/core-alert-job/src/main/java/by/gdev/alert/job/core/service/CoreService.java
+++ b/core-alert-job/src/main/java/by/gdev/alert/job/core/service/CoreService.java
@@ -11,11 +11,13 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.util.CollectionUtils;
+import org.springframework.util.StringUtils;
 import org.springframework.web.reactive.function.client.WebClient;
 
 import com.google.common.collect.Sets;
 
 import by.gdev.alert.job.core.configuration.ApplicationProperty;
+import by.gdev.alert.job.core.exeption.InvalidWebhookUrlException;
 import by.gdev.alert.job.core.model.AlertTime;
 import by.gdev.alert.job.core.model.AppUserDTO;
 import by.gdev.alert.job.core.model.Modules;
@@ -36,6 +38,7 @@ import by.gdev.alert.job.core.repository.UserFilterRepository;
 import by.gdev.common.exeption.CollectionLimitExeption;
 import by.gdev.common.exeption.ConflictExeption;
 import by.gdev.common.exeption.ResourceNotFoundException;
+import by.gdev.common.util.WebhookUrlValidator;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import reactor.core.publisher.Flux;
@@ -117,6 +120,29 @@ public class CoreService {
 			user.setDefaultSendType(defaultSend);
 			user = userRepository.save(user);
 			m.success(user.isDefaultSendType());
+		});
+	}
+
+	public Mono<Void> changeUserWebhook(String uuid, String webhookUrl) {
+		// Адрес проверяем до сборки Mono: исключение из тела Mono всплывёт уже
+		// после того, как статус ответа отдан, и обработчик его не увидит.
+		String url = StringUtils.hasText(webhookUrl) ? webhookUrl.trim() : null;
+		if (url != null) {
+			try {
+				WebhookUrlValidator.validate(url);
+			} catch (IllegalArgumentException e) {
+				throw new InvalidWebhookUrlException(e.getMessage());
+			}
+		}
+
+		return Mono.create(m -> {
+			AppUser user = userRepository.findByUuid(uuid)
+					.orElseThrow(() -> new ResourceNotFoundException("user not found"));
+			user.setWebhookUrl(url);
+			// Смена адреса — повод дать каналу второй шанс.
+			user.setWebhookFailCount(0);
+			userRepository.save(user);
+			m.success();
 		});
 	}
 

--- a/core-alert-job/src/main/java/by/gdev/alert/job/core/service/OrderProcessor.java
+++ b/core-alert-job/src/main/java/by/gdev/alert/job/core/service/OrderProcessor.java
@@ -46,6 +46,7 @@ public class OrderProcessor {
     private final ApplicationProperty property;
     private final UserFilterRepository filterRepository;
     private final MailSenderService mailSenderService;
+    private final WebhookSenderService webhookSenderService;
 
     private final AccountTemplateBindingRepository accountTemplateBindingRepository;
     private final UserSiteCredentialRepository userSiteCredentialRepository;
@@ -184,6 +185,10 @@ public class OrderProcessor {
     }
 
     private void sendOrderToUser(AppUser user, List<OrderDTO> list) {
+        // Webhook — канал для машин: он не ждёт окна оповещений и не заменяет
+        // почту с телеграмом, а работает рядом с ними.
+        webhookSenderService.sendOrders(user, list);
+
         if (CollectionUtils.isEmpty(user.getUserAlertTimes()) || isMatchUserAlertTimes(user)) {
             Map<String, List<OrderDTO>> byLink = list.stream().collect(Collectors.groupingBy(OrderDTO::getLink));
             List<String> resultOrdersString = byLink.entrySet().stream().map(entry -> {

--- a/core-alert-job/src/main/java/by/gdev/alert/job/core/service/WebhookSenderService.java
+++ b/core-alert-job/src/main/java/by/gdev/alert/job/core/service/WebhookSenderService.java
@@ -1,0 +1,87 @@
+package by.gdev.alert.job.core.service;
+
+import java.time.Instant;
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import by.gdev.alert.job.core.model.db.AppUser;
+import by.gdev.alert.job.core.repository.AppUserRepository;
+import by.gdev.common.util.WebhookUrlValidator;
+import by.gdev.common.model.NotificationType;
+import by.gdev.common.model.OrderDTO;
+import by.gdev.common.model.WebhookNotification;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang.StringUtils;
+
+/**
+ * Доставка заказов на пользовательский webhook.
+ *
+ * Канал независимый: он не заменяет почту и телеграм, а работает рядом с ними,
+ * поэтому пользователь может получать письма и одновременно отдавать заказы
+ * в свою систему. Расписание тишины (UserAlertTime) на webhook не влияет —
+ * оно про людей, а не про интеграции.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class WebhookSenderService {
+
+	private static final String SEND_WEBHOOK_URL = "http://notification:8019/webhook";
+
+	private final WebClient webClient;
+	private final AppUserRepository userRepository;
+
+	@Value("${webhook.max.failures:10}")
+	private int maxWebhookFailures;
+
+	public void sendOrders(AppUser user, List<OrderDTO> orders) {
+		send(user, orders, NotificationType.ORDER);
+	}
+
+	public void send(AppUser user, List<OrderDTO> orders, NotificationType type) {
+		String url = user.getWebhookUrl();
+		if (StringUtils.isEmpty(url) || orders == null || orders.isEmpty()) {
+			return;
+		}
+		if (!user.isSwitchOffAlerts()) {
+			log.debug("Webhook skipped, alerts are off for user {}", user.getUuid());
+			return;
+		}
+		Integer failCount = user.getWebhookFailCount();
+		if (failCount != null && failCount >= maxWebhookFailures) {
+			log.debug("Webhook disabled for user {} after {} failures", user.getUuid(), failCount);
+			return;
+		}
+		if (!WebhookUrlValidator.isValid(url)) {
+			// Адрес мог стать невалидным уже после сохранения — например, домен
+			// начал резолвиться во внутренний адрес.
+			log.warn("Webhook url of user {} is no longer valid, skipping", user.getUuid());
+			return;
+		}
+
+		WebhookNotification notification = new WebhookNotification(url, user.getUuid(), type,
+				Instant.now().toString(), orders);
+
+		webClient.post().uri(SEND_WEBHOOK_URL).bodyValue(notification).retrieve().bodyToMono(Void.class)
+				.subscribe(success -> resetFailures(user), error -> registerFailure(user, error));
+	}
+
+	private void resetFailures(AppUser user) {
+		if (user.getWebhookFailCount() != null && user.getWebhookFailCount() > 0) {
+			user.setWebhookFailCount(0);
+			userRepository.save(user);
+		}
+		log.debug("Webhook delivered for user {}", user.getUuid());
+	}
+
+	private void registerFailure(AppUser user, Throwable error) {
+		int newCount = user.getWebhookFailCount() == null ? 1 : user.getWebhookFailCount() + 1;
+		user.setWebhookFailCount(newCount);
+		userRepository.save(user);
+		log.warn("Webhook failed for user {}, fail count {}: {}", user.getUuid(), newCount, error.getMessage());
+	}
+}

--- a/front/src/layouts/notificationPage/webhookSource/WebhookSource.jsx
+++ b/front/src/layouts/notificationPage/webhookSource/WebhookSource.jsx
@@ -1,0 +1,47 @@
+import React, { useEffect, useState } from 'react';
+
+import TextField from '@mui/material/TextField';
+
+import { coreService } from '../../../services/parser/endponits/coreService';
+
+const WebhookSource = (props) => {
+	const { webhookUrl, updateWebhookUrl } = props;
+
+	const [url, setUrl] = useState('')
+	const [error, setError] = useState('')
+
+	useEffect(() => {
+		setUrl(webhookUrl || '')
+	}, [webhookUrl])
+
+	const saveWebhookUrl = e => {
+		const value = e.target.value.trim()
+
+		if (value === (webhookUrl || '')) {
+			return
+		}
+
+		coreService.changeWebhookUrl(value)
+			.then(() => {
+				setError('')
+				updateWebhookUrl(value)
+			})
+			.catch(() => setError('Адрес не принят: нужен внешний http(s) адрес'))
+	}
+
+	return <div className='notification_source'>
+		<TextField
+			fullWidth
+			label='Webhook (необязательно)'
+			value={url}
+			onChange={(e) => setUrl(e.target.value)}
+			onBlur={saveWebhookUrl}
+			variant='standard'
+			placeholder='https://example.com/hooks/alert-job'
+			error={Boolean(error)}
+			helperText={error || 'Заказы будут дублироваться POST-запросом с JSON. Пусто — выключено.'}
+		/>
+	</div>
+}
+
+export default WebhookSource;

--- a/front/src/pages/notificationsPage/NotificationsPage.jsx
+++ b/front/src/pages/notificationsPage/NotificationsPage.jsx
@@ -3,6 +3,7 @@ import React, { useState, useEffect } from 'react'
 import Title from '../../components/common/title/Title'
 import InstructionForTg from '../../components/notification/instructionForTg/InstructionForTg'
 import NotificationSource from '../../layouts/notificationPage/norificationSource/NotificationSource';
+import WebhookSource from '../../layouts/notificationPage/webhookSource/WebhookSource';
 import AlertStatus from '../../layouts/notificationPage/alertStatus/AlertStatus';
 import AlertTime from '../../layouts/notificationPage/alertTime/AlertTime';
 import Btn from '../../components/common/button/Button';
@@ -21,6 +22,7 @@ const NotificationsPage = () => {
 	const [isOpenTime, setIsOpenTime] = useState(false)
 	const [alertType, setAlertType] = useState()
 	const [email, setEmail] = useState('')
+	const [webhookUrl, setWebhookUrl] = useState('')
 
 	const { handleStatus } = changeAuthStatus()
 
@@ -41,6 +43,7 @@ const NotificationsPage = () => {
 				setAlertType(response.data.defaultSendType)
 				setTelegramId(response.data.telegram === null ? '' : response.data.telegram)
 				setEmail(response.data.email)
+				setWebhookUrl(response.data.webhookUrl === null ? '' : response.data.webhookUrl)
 				if (response.data.defaultSendType) {
 					return setCurrentPlatform({ name: 'email', id: 1 })
 				}
@@ -65,6 +68,10 @@ const NotificationsPage = () => {
 		setTelegramId(newId)
 	}
 
+	const updateWebhookUrl = (newUrl) => {
+		setWebhookUrl(newUrl)
+	}
+
 	return <div className='notification_page'>
 		<div className='container'>
 			<Title text='Настройка уведомлений' />
@@ -76,6 +83,7 @@ const NotificationsPage = () => {
 				email={email}
 				updateTelegramId={updateTelegramId}
 			/>
+			<WebhookSource webhookUrl={webhookUrl} updateWebhookUrl={updateWebhookUrl} />
 			<AlertStatus alertStatus={alertStatus} handleAlertsStatus={handleAlertsStatus} />
 			<Btn className='mt-1' text={isOpenTime ? 'Скрыть настройку время оповещения' : 'Показать настройки время оповещения'} onClick={handleShowsAlertTime} />
 			{isOpenTime && <AlertTime shedule={shedule} />}

--- a/front/src/services/parser/endponits/coreService.js
+++ b/front/src/services/parser/endponits/coreService.js
@@ -9,7 +9,8 @@ const coreService = {
 	removeAlertTime: (id) => api.delete(`user/alert-time/${id}`),
 	changeAlertsStatus: (status) => api.patch(`user/alerts?status=${status}`),
 	changeAlertsType: (default_send) => api.patch(`user/alerts/type?default_send=${default_send}`),
-	changeTgId: (id) => api.patch(`user/telegram?telegram_id=${id}`)
+	changeTgId: (id) => api.patch(`user/telegram?telegram_id=${id}`),
+	changeWebhookUrl: (url) => api.patch(`user/webhook?url=${encodeURIComponent(url)}`)
 }
 
 export { coreService }

--- a/notification-alert-job/src/main/java/by/gdev/alert/job/notification/config/MetricsConfig.java
+++ b/notification-alert-job/src/main/java/by/gdev/alert/job/notification/config/MetricsConfig.java
@@ -15,12 +15,16 @@ public class MetricsConfig {
     public static final String COUNTER_TELEGRAM_NEGATIVE = "counter_telegram_negative";
     public static final String COUNTER_MAIL_POSITIVE = "counter_mail_positive";
     public static final String COUNTER_MAIL_NEGATIVE = "counter_mail_negative";
+    public static final String COUNTER_WEBHOOK_POSITIVE = "counter_webhook_positive";
+    public static final String COUNTER_WEBHOOK_NEGATIVE = "counter_webhook_negative";
     private static final String TELEGRAM_COUNTER_NAME = "notification_telegram";
     private static final String MAIL_COUNTER_NAME = "notification_mail";
+    private static final String WEBHOOK_COUNTER_NAME = "notification_webhook";
     private static final String POSITIVE_TAG = "positive";
     private static final String NEGATIVE_TAG = "negative";
     private static final String TELEGRAM_TAG = "telegram";
     private static final String MAIL_TAG = "mail";
+    private static final String WEBHOOK_TAG = "webhook";
 
     @Autowired
     private ApplicationContext context;
@@ -35,5 +39,8 @@ public class MetricsConfig {
 
         beanFactory.registerSingleton(COUNTER_MAIL_POSITIVE, meterRegistry.counter(MAIL_COUNTER_NAME, MAIL_TAG, POSITIVE_TAG));
         beanFactory.registerSingleton(COUNTER_MAIL_NEGATIVE, meterRegistry.counter(MAIL_COUNTER_NAME, MAIL_TAG, NEGATIVE_TAG));
+
+        beanFactory.registerSingleton(COUNTER_WEBHOOK_POSITIVE, meterRegistry.counter(WEBHOOK_COUNTER_NAME, WEBHOOK_TAG, POSITIVE_TAG));
+        beanFactory.registerSingleton(COUNTER_WEBHOOK_NEGATIVE, meterRegistry.counter(WEBHOOK_COUNTER_NAME, WEBHOOK_TAG, NEGATIVE_TAG));
     }
 }

--- a/notification-alert-job/src/main/java/by/gdev/alert/job/notification/controller/WebhookController.java
+++ b/notification-alert-job/src/main/java/by/gdev/alert/job/notification/controller/WebhookController.java
@@ -1,0 +1,25 @@
+package by.gdev.alert.job.notification.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import by.gdev.alert.job.notification.service.WebhookService;
+import by.gdev.common.model.WebhookNotification;
+import lombok.RequiredArgsConstructor;
+import reactor.core.publisher.Mono;
+
+@RestController
+@RequestMapping
+@RequiredArgsConstructor
+public class WebhookController {
+
+	private final WebhookService service;
+
+	@PostMapping("webhook")
+	public ResponseEntity<Mono<Void>> sendWebhook(@RequestBody WebhookNotification notification) {
+		return ResponseEntity.ok(service.send(notification));
+	}
+}

--- a/notification-alert-job/src/main/java/by/gdev/alert/job/notification/service/WebhookService.java
+++ b/notification-alert-job/src/main/java/by/gdev/alert/job/notification/service/WebhookService.java
@@ -1,0 +1,71 @@
+package by.gdev.alert.job.notification.service;
+
+import java.net.URI;
+import java.time.Duration;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.ApplicationContext;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import by.gdev.alert.job.notification.config.MetricsConfig;
+import by.gdev.common.model.WebhookNotification;
+import by.gdev.common.util.WebhookUrlValidator;
+import io.micrometer.core.instrument.Counter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import reactor.core.publisher.Mono;
+
+/**
+ * Доставка уведомления на пользовательский webhook.
+ *
+ * Адрес приходит от пользователя, поэтому проверяется здесь ещё раз — модуль
+ * стоит внутри docker-сети, и запрос по внутреннему адресу был бы SSRF.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class WebhookService {
+
+	private static final String EVENT_HEADER = "X-AlertJob-Event";
+	private static final String USER_HEADER = "X-AlertJob-User";
+
+	private final WebClient webClient;
+	private final ApplicationContext context;
+
+	@Value("${webhook.timeout.seconds:15}")
+	private int timeoutSeconds;
+
+	public Mono<Void> send(WebhookNotification notification) {
+		Counter positive = context.getBean(MetricsConfig.COUNTER_WEBHOOK_POSITIVE, Counter.class);
+		Counter negative = context.getBean(MetricsConfig.COUNTER_WEBHOOK_NEGATIVE, Counter.class);
+
+		if (notification == null || !WebhookUrlValidator.isValid(notification.getUrl())) {
+			log.warn("Webhook rejected: url is not allowed");
+			negative.increment();
+			return Mono.empty();
+		}
+
+		return webClient.post().uri(URI.create(notification.getUrl()))
+				.header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+				.header(EVENT_HEADER, String.valueOf(notification.getType()))
+				.header(USER_HEADER, String.valueOf(notification.getUserUuid()))
+				.bodyValue(notification)
+				.retrieve()
+				.bodyToMono(Void.class)
+				.timeout(Duration.ofSeconds(timeoutSeconds))
+				.doOnSuccess(r -> {
+					log.info("sent webhook for user {}, orders {}", notification.getUserUuid(),
+							notification.getOrders() == null ? 0 : notification.getOrders().size());
+					positive.increment();
+				})
+				.onErrorResume(ex -> {
+					log.warn("Could not send webhook for user {}: {}", notification.getUserUuid(), ex.getMessage());
+					negative.increment();
+					return Mono.error(ex);
+				})
+				.then();
+	}
+}


### PR DESCRIPTION
## Зачем

Сейчас заказы уходят пользователю только письмом или в телеграм — обоими каналами человеку. Если заказы нужны другой системе (CRM, свой бот, скрипт автоответов), её приходится подключать через разбор писем: неудобно и ломается при смене шаблона.

Этот PR добавляет третий канал — доставку на пользовательский HTTP-эндпоинт. В отличие от почты и телеграма туда уходит не отрендеренная строка, а сами `OrderDTO` в JSON.

## Что сделано

| Модуль | Изменения |
|---|---|
| `common-alert-job` | `WebhookNotification` (payload), `WebhookUrlValidator` + юнит-тесты |
| `core-alert-job` | `AppUser.webhookUrl` / `webhookFailCount`, `PATCH /api/user/webhook?url=`, `WebhookSenderService`, вызов из `OrderProcessor.sendOrderToUser` |
| `notification-alert-job` | `POST /webhook`, `WebhookService`, счётчики Prometheus `notification_webhook` |
| `front` | поле вебхука на странице настройки уведомлений |
| `README.md`, `README_RU.md` | описание канала и пример payload |

Тело запроса на адрес пользователя:

```json
{
  "url": "https://example.com/hooks/alert-job",
  "userUuid": "0d2c...",
  "type": "ORDER",
  "sentAt": "2025-09-01T10:15:30Z",
  "orders": [
    {
      "title": "Нужен парсер на Python",
      "link": "https://freelance.ru/projects/1",
      "dateTime": "2025-09-01T10:15:00Z",
      "price": { "value": 15000, "currency": "RUB" },
      "sourceSite": { "categoryName": "Разработка", "subCategoryName": "Python" },
      "moduleName": "Backend"
    }
  ]
}
```

Заголовки: `X-AlertJob-Event` (тип события), `X-AlertJob-User` (uuid получателя).

## Решения, которые стоит обсудить

**Канал независимый.** Он не заменяет почту и телеграм, а работает рядом с ними, поэтому `defaultSendType` не трогается и существующее поведение не меняется. Расписание тишины (`UserAlertTime`) на webhook не влияет — оно про людей, а не про интеграции; общий тумблер уведомлений (`switchOffAlerts`) канал выключает. Если предпочитаете, чтобы webhook подчинялся и расписанию — поправлю.

**SSRF.** Адрес задаёт пользователь, а запрос по нему делает `notification`, который стоит внутри docker-сети рядом с `core`, `keycloak` и базой. Без проверки пользователь указал бы `http://core:8017/...` и заставил бы сервис ходить по внутренним адресам от своего имени. Поэтому `WebhookUrlValidator` пропускает только внешние `http`/`https` и отклоняет loopback, приватные, link-local и multicast адреса. Проверка стоит дважды: при сохранении (ответ 400) и перед доставкой.

**Тихое отключение при сбоях.** По образцу `telegramFailCount`: после `webhook.max.failures` (по умолчанию 10) неудач подряд канал замолкает, сохранение нового адреса сбрасывает счётчик. Успешная доставка обнуляет счётчик.

**Новые свойства** (обе с дефолтами, менять конфиг не обязательно): `webhook.max.failures` в core, `webhook.timeout.seconds` в notification.

## Миграция схемы

В `AppUser` добавлены два поля. Если на проде `spring.jpa.hibernate.ddl-auto=update`, схема подтянется сама. Если `validate` — нужно добавить колонки вручную:

```sql
ALTER TABLE app_user ADD COLUMN webhook_url VARCHAR(512) NULL;
ALTER TABLE app_user ADD COLUMN webhook_fail_count INT NOT NULL DEFAULT 0;
```

Подскажите, какой вариант у вас — при необходимости добавлю скрипт в PR.

## Проверка

- `mvn -pl common-alert-job,core-alert-job,notification-alert-job -am compile` — BUILD SUCCESS
- `mvn -pl common-alert-job test` — `WebhookUrlValidatorTest`, 4 теста, все зелёные
- Фронтовые файлы проверены на синтаксис (esbuild); полный `npm run build` не гонял
- Сквозной прогон на живом стенде не делал — нет поднятого окружения

Готов доработать по замечаниям: имена полей, семантика расписания, формат payload, подпись запроса (HMAC) — если она вам нужна, добавлю отдельным коммитом.